### PR TITLE
域名加了个www

### DIFF
--- a/resources/membership.json
+++ b/resources/membership.json
@@ -133,8 +133,8 @@
 		"github_username": "maolog"
 	},
 	"22": {
-		"domain": "yuanzj.top",
-		"icon": "https://yuanzj.top/img/favicon.jpg",
+		"domain": "www.yuanzj.top",
+		"icon": "https://www.yuanzj.top/img/favicon.jpg",
 		"name": "圆周率的博客",
 		"description": "My Blog!",
 		"github_username": "yzl3014"


### PR DESCRIPTION
原域名`yuanzj.top`因CNAME技术问题导致CDN节点不全，近日决定做301跳转`www.yuanzj.top`。 但是加了www后数据不再统计，因此专门修改。